### PR TITLE
Move "object oriented programming" after Object Types, before OOP Macro

### DIFF
--- a/content/toc.md
+++ b/content/toc.md
@@ -9,7 +9,6 @@
 * [Case Statements](/case/)
 * [For Loops & Iterators](/for_iterators/)
 * [Procs](/procs/)
-* [Object Oriented Programming](/oop/)
 * [First Class Functions](/procvars/)
 * [Blocks](/block/)
 * [Primitive Types](/primitives/)
@@ -22,6 +21,7 @@
 * [Seqs](/seqs/)
 * [Bitsets](/bitsets/)
 * [Varargs](/varargs/)
+* [Object Oriented Programming](/oop/)
 * [OOP Macro](/oop_macro/)
 
 <!-- * OpenGL  * [Triangle](/opengl/triangle/)-->


### PR DESCRIPTION
I'm assuming a simple change to the toc.md is all that is needed. I'm not familiar with nanoc.
