### PR TITLE
Fix oop macro to work with latest Nim

### DIFF
--- a/content/content/oop_macro.md
+++ b/content/content/oop_macro.md
@@ -105,12 +105,12 @@ macro class*(head, body: untyped): untyped =
   #               Empty
 
   # create a type section in the result
-  result =
-    if exported:
-      # mark `typeName` with an asterisk
+  if exported:
+    result =
       quote do:
         type `typeName`* = ref object of `baseName`
-    else:
+  else:
+    result =
       quote do:
         type `typeName` = ref object of `baseName`
 
@@ -167,8 +167,8 @@ macro class*(head, body: untyped): untyped =
           # specify the return type of the ctor proc
           node.params[0] = typeName
         else:
-          # inject `self: T` into the arguments
-          node.params.insert(1, newIdentDefs(ident("self"), typeName))
+          # inject `this: T` into the arguments
+          node.params.insert(1, newIdentDefs(ident("this"), typeName))
         result.add(node)
 
       of nnkVarSection:


### PR DESCRIPTION
The oop_macro.md had an error with using `self` instead of `this`. With the latest Nim, the call to `quote do:` also causes an error when inside an `if` expression assigned to a variable. Not sure if this behavior is intended by Nim devs or not, but it definitely causes some confusion.