### PR TITLE
fix LaTeX artifacts in bitsets.md

### DIFF
--- a/content/content/bitsets.md
+++ b/content/content/bitsets.md
@@ -4,9 +4,9 @@ title: Bitsets
 
 # Bitsets
 
-Nim comes with a built in way to build a set of ordinal types. In order for a type to be usable in a bitset, it must be an ordinal and <<\texttt{high(T)} < 2^{16}>>. For sets of non-ordinal types, see the [sets module](http://nim-lang.org/sets.html), which contains hashsets.
+Nim comes with a built in way to build a set of ordinal types. In order for a type to be usable in a bitset, it must be an ordinal and <<`high(T)` < 2<sup>16</sup>>>. For sets of non-ordinal types, see the [sets module](http://nim-lang.org/sets.html), which contains hashsets.
 
-However, best practice is to keep bitset size significantly smaller since each possible element in the set consumes one bit, therefore a bitset of <<2^{16}>> elements will consume 64KiB.
+However, best practice is to keep bitset size significantly smaller since each possible element in the set consumes one bit, therefore a bitset of <<2<sup>16</sup>>> elements will consume 64KiB.
 
 Bitsets have all the useful operations of mathematical sets:
 


### PR DESCRIPTION
Was this originally latex, and converted using pandoc or something like that? Happy to change this if I misinterpreted the intent of `\texttt{...}`.