### PR TITLE
Fix bitsets examples

### DIFF
--- a/content/content/bitsets.md
+++ b/content/content/bitsets.md
@@ -10,15 +10,14 @@ However, best practice is to keep bitset size significantly smaller since each p
 
 Bitsets have all the useful operations of mathematical sets:
 
-|Operator     | Description                   | Example Code                                 |
+| Operator    | Description                   | Example Code                                 |
 |-------------|-------------------------------|----------------------------------------------|
 | `a in B`    | is a an element of B?         | `'d' in {'a'..'z'}`                          |
 | `a notin B` | is a not an element of B?     | `40 notin {2..20} `                          |
 | `A + B`     | union of A with B             | `{'a'..'m'} + {'n'..'z'} == {'a'..'z'}`      |
 | `A - B`     | relative complement of A in B | `{'a'..'z'} - {'b'..'d'} == {'a', 'e'..'z'}` |
-| `A + b`     | add element b to set A        | `{'b'..'z'} + 'a' == {'a'..'z'}`             |
-| `A - b`     | remove element b from set A   | `{'a'..'z'} - 'a' == {'b'..'z'}`             |
-| `A * B`     | intersection of A with B      | `{'a'..'m'} * {'c'..'z} == {'c'..'m'}`       |
+| `A + {b}`   | add element b to set A        | `{'b'..'z'} + {'a'} == {'a'..'z'}`           |
+| `A - {b}`   | remove element b from set A   | `{'a'..'z'} - {'a'} == {'b'..'z'}`           |
+| `A * B`     | intersection of A with B      | `{'a'..'m'} * {'c'..'z'} == {'c'..'m'}`      |
 | `A <= B`    | is A a subset of B?           | `{'a'..'c'} <= {'a'..'z'}`                   |
 | `A < B`     | is A a strict subset of B?    | `{'b'..'c'} < {'a'..'z'}`                    |
-


### PR DESCRIPTION
You cannot do (A + e) or (A - e) where A is a set and e is an
element. But you can do (A + {e}) or (A - {e}).

Ref:

- https://nim-lang.org/docs/manual.html#types-set-type

This commit also fixes a typo, the missing quote in the intersection
example.

Fixes https://github.com/flaviut/nim-by-example/issues/72.

---

I have been preparing my own set of notes where I evaluate every code snippet in there on the latest Nim devel when I get chance, and that's how this issue come up on https://gitter.im/nim-lang/Nim?at=5be453577326df140ed4665d.

My notes on bitsets adapted from yours: https://scripter.co/notes/nim/#bitsets--set-type.
