### PR TITLE
string init no longer necessary

### DIFF
--- a/content/content/variables/result.md
+++ b/content/content/variables/result.md
@@ -7,7 +7,6 @@ The `result` variable is a special variable that serves as an implicit return va
 
 ``` nimrod
 proc getAlphabet(): string =
-  result = ""
   for letter in 'a'..'z':
     result.add(letter)
 ```


### PR DESCRIPTION
string used to be inited to nil, so ``result = ""` was necessary. But they now are inited to ``""``, so you don't have to do that explicitly.