### PR TITLE
File Example Update: move defer statment into proc

### DIFF
--- a/content/content/files.md
+++ b/content/content/files.md
@@ -24,12 +24,15 @@ echo entireFile  # prints the entire file
 We can also read the lines of a file by opening a `File` object and using the `readLine` proc to read individual lines.
 
 ``` nimrod
-let f = open("kittens.txt")
-# Close the file object when you are done with it
-defer: f.close()
+proc readKittens() =
+  let f = open("kittens.txt")
+  # Close the file object when you are done with it
+  defer: f.close()
 
-let firstLine = f.readLine()
-echo firstLine  # prints Spitfire
+  let firstLine = f.readLine()
+  echo firstLine  # prints Spitfire
+
+readKittens()
 ```
 
 ## Writing to a File
@@ -46,13 +49,16 @@ This will create a file on the system named `cats.txt` containing "Cats are very
 We can also write a file line by line using a `File` object and the `writeLine` proc.
 
 ``` nimrod
-let lines = ["Play", "Eat", "Sleep"]
-# The fmWrite constant specifies that we are opening the file for writing.
-let f = open("catactivities.txt", fmWrite)
-defer: f.close()
+proc writeCatActivities() =
+  let lines = ["Play", "Eat", "Sleep"]
+  # The fmWrite constant specifies that we are opening the file for writing.
+  let f = open("catactivities.txt", fmWrite)
+  defer: f.close()
 
-for line in lines:
-  f.writeLine(line)
+  for line in lines:
+    f.writeLine(line)
+
+writeCatActivities()
 ```
 
 After running this program there should be a file called `catactivities.txt` with the following contents.


### PR DESCRIPTION
Hello! 👋🏻 

I was working my way through all of the examples and came across an error that would not allow the File examples to run. Was specifically running into this error in Nim 1.4.8

```
Error: defer statement not supported at top level
```

I'm still very new to Nim, but I'm assuming this used to be valid. Nesting the defer statements in a proc seems to work fine and I've updated the examples to do just that.

__Commit Message__ \
The `defer` statment is not supported at the top-level. Update the examples
to nest `defer` in a `proc` to remain runnable.

---

__P.S.__ \
This guide has been very helpful to learning Nim, thank you for your hard work to make this!! :-) 