### PR TITLE
Correct Incorrect Quantity

### DIFF
--- a/content/content/bitsets.md
+++ b/content/content/bitsets.md
@@ -6,7 +6,7 @@ title: Bitsets
 
 Nim comes with a built in way to build a set of ordinal types. In order for a type to be usable in a bitset, it must be an ordinal and <<\texttt{high(T)} < 2^{16}>>. For sets of non-ordinal types, see the [sets module](http://nim-lang.org/docs/sets.html), which contains hashsets.
 
-However, best practice is to keep bitset size significantly smaller since each possible element in the set consumes one bit, therefore a bitset of <<2^{16}>> elements will consume 64KiB.
+However, best practice is to keep bitset size significantly smaller since each possible element in the set consumes one bit, therefore a bitset of <<2^{16}>> elements will consume 65,536 bits (i.e. 8,192 bytes, or 8KiB).
 
 Bitsets have all the useful operations of mathematical sets:
 


### PR DESCRIPTION
The bitsets tutorial currently says:
> However, best practice is to keep bitset size significantly smaller since each possible element in the set consumes one bit, therefore a bitset of 2<sup>16</sup> elements will consume 64KiB.

But this is incorrect, 64KiB would be 2<sup>16</sup> _bytes_, not bits. 2<sup>16</sup> bits is actually _8KiB_.

This PR corrects the mistake in the text.